### PR TITLE
Fix/cs 478 miw ssi lib integration test is failing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-      
+
       - name: Set up codeql
         uses: github/codeql-action/init@v2
         with:
@@ -57,9 +57,12 @@ jobs:
         env:
           GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
           GITHUB_PACKAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
       - name: Run tests
         run: ./mvnw -B test --file ./pom.xml
+
+      - name: Run integration tests
+        run: ./mvnw -B integration-test --file ./pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,6 +63,3 @@ jobs:
 
       - name: Run tests
         run: ./mvnw -B test --file ./pom.xml
-
-      - name: Run integration tests
-        run: ./mvnw -B integration-test --file ./pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -294,12 +294,14 @@ SPDX-License-Identifier: Apache-2.0
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.1.2</version>
                 <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
+                  <execution>
+                    <id>integration-test</id>
+                    <goals>
+                      <goal>integration-test</goal>
+                      <goal>verify</goal>
+                    </goals>
+                    <phase>test</phase>
+                  </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
@@ -62,7 +62,7 @@ public class DidUniResolverIT {
    */
   @Container
   public static GenericContainer<?> uniResolver =
-      new GenericContainer<>("universalresolver/driver-did-key:latest")
+      new GenericContainer<>("universalresolver/driver-did-key:0.2.0-f98a04a")
           .withExposedPorts(8080)
           .waitingFor(new HostPortWaitStrategy());
 


### PR DESCRIPTION
Ref: https://cofinity-x.atlassian.net/browse/CS-478


In current pipeline, we are only running test using maven, we need to run integration test also

We have used universalresolver/driver-did-key  docker image to test did:key resolve integration test and in latest version of docker file did document response is changes and due to that we are getting below error:



```

Caused by: java.lang.IllegalArgumentException: Invalid JsonLdObject: {"didDocument":{"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/suites/jws-2020/v1"],"id":"did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6","verificationMethod":[{"id":"did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6","type":"JsonWebKey2020","controller":"did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6","publicKeyJwk":{"kty":"OKP","crv":"Ed25519","x":"FN5URrQRnKSaEjQvC8e6vpNGxivoocgPLgmzv_5JH2k"}}],"assertionMethod":["did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"],"authentication":["did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"],"capabilityInvocation":["did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"],"capabilityDelegation":["did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6#z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"]}}
	at org.eclipse.tractusx.ssi.lib.model.JsonLdObject.<init>(JsonLdObject.java:71)
	at org.eclipse.tractusx.ssi.lib.model.did.DidDocument.<init>(DidDocument.java:53)
	at org.eclipse.tractusx.ssi.lib.model.did.DidDocument.fromJson(DidDocument.java:104)
	at org.eclipse.tractusx.ssi.lib.did.resolver.DidUniResolver.resolve(DidUniResolver.java:92)
	... 72 more
Caused by: java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "context" is null
	at org.eclipse.tractusx.ssi.lib.model.JsonLdObject.getContext(JsonLdObject.java:101)
	at org.eclipse.tractusx.ssi.lib.model.JsonLdObject.<init>(JsonLdObject.java:59)

```