### PR TITLE
chore: exclude examples directory from test coverage in sonarcloud

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0 #added for sonar analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@ SPDX-License-Identifier: Apache-2.0
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectName>SSI-agent-lib</sonar.projectName>
         <sonar.java.source>17</sonar.java.source>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.exclusions>
             src/main/java/org/eclipse/tractusx/ssi/examples/** 
         </sonar.coverage.exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@ SPDX-License-Identifier: Apache-2.0
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectName>SSI-agent-lib</sonar.projectName>
         <sonar.java.source>17</sonar.java.source>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.exclusions>
+            src/main/java/org/eclipse/tractusx/ssi/examples/** 
+        </sonar.coverage.exclusions>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- exclude examples directory from coverage report  as it does not contain any production code which needs to be tested
- Add fetch-depth:0 to fix sonar cloud warning on analysis 

<img width="561" alt="Screenshot 2024-03-08 at 10 33 43" src="https://github.com/Cofinity-X/SSI-agent-lib/assets/150015372/908e6eec-146f-4c89-898a-07537db9eb3f">



Refs: ABC-208 