### PR TITLE
fix: multibase string added in proof value

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofGenerator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofGenerator.java
@@ -152,7 +152,7 @@ public class LinkedDataProofGenerator {
     if (type == SignatureType.ED25519) {
 
       final MultibaseString multibaseString = MultibaseFactory.create(signature);
-      proof.put(Ed25519Signature2020.PROOF_VALUE, multibaseString);
+      proof.put(Ed25519Signature2020.PROOF_VALUE, multibaseString.getEncoded());
     } else {
       proof.put(JWSSignature2020.JWS, new String(signature, StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
Put encoded string in case of Ed255195 proof type

```
 "proof":
            {
                "proofPurpose": "assertionMethod",
                "verificationMethod": "did:web:localhost%3A54911#key-1",
                "type": "Ed25519Signature2020",
                "proofValue":
                {
                    "encoded": "z4vCUNNxV4z1vGNPYR93TLZn5jyx6xYQAJ7b6gpFGf9AgaGELFUKD3NiZrFEgGS1uFbzm9R7gEoQmofkZAWakm85o"
                },
                "created": "2024-04-25T07:09:53Z"
            }
```