### PR TITLE
feat: credentialSubject as object support added in vc

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
@@ -112,7 +112,7 @@ public class VerifiableCredential extends Verifiable {
           String.format("Invalid VerifiableCredential: %s", SerializeUtil.toJson(json)), e);
     }
 
-    if (getCredentialSubject().isEmpty()) {
+    if (Objects.isNull(getCredentialSubject())) {
       throw new IllegalArgumentException(
           String.format(
               "Invalid VerifiableCredential. CredentialSubject must not be empty: %s",
@@ -172,14 +172,11 @@ public class VerifiableCredential extends Verifiable {
    * @return the credential subject
    */
   @NonNull
-  public List<VerifiableCredentialSubject> getCredentialSubject() {
+  public VerifiableCredentialSubject getCredentialSubject() {
     Object subject = get(CREDENTIAL_SUBJECT);
 
-    if (subject instanceof List) {
-      return ((List<Map<String, Object>>) subject)
-          .stream().map(VerifiableCredentialSubject::new).toList();
-    } else if (subject instanceof Map) {
-      return List.of(new VerifiableCredentialSubject((Map<String, Object>) subject));
+    if (subject instanceof Map) {
+      return new VerifiableCredentialSubject((Map<String, Object>) subject);
     } else {
       throw new IllegalArgumentException(
           "Invalid credential subject type. "

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
@@ -43,7 +43,7 @@ public class VerifiableCredentialBuilder {
   private URI issuer;
   private Instant issuanceDate;
   private Instant expirationDate;
-  private List<VerifiableCredentialSubject> credentialSubject;
+  private VerifiableCredentialSubject credentialSubject;
   private Proof proof;
   private VerifiableCredentialStatus credentialStatus;
 
@@ -120,20 +120,8 @@ public class VerifiableCredentialBuilder {
    * @return the verifiable credential builder
    */
   public VerifiableCredentialBuilder credentialSubject(
-      List<VerifiableCredentialSubject> credentialSubject) {
-    this.credentialSubject = credentialSubject;
-    return this;
-  }
-
-  /**
-   * Credential subject verifiable credential builder.
-   *
-   * @param credentialSubject the credential subject
-   * @return the verifiable credential builder
-   */
-  public VerifiableCredentialBuilder credentialSubject(
       VerifiableCredentialSubject credentialSubject) {
-    this.credentialSubject = List.of(credentialSubject);
+    this.credentialSubject = credentialSubject;
     return this;
   }
 

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/proof/proof/LinkedDataTransformerTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/proof/proof/LinkedDataTransformerTest.java
@@ -36,8 +36,7 @@ class LinkedDataTransformerTest {
 
   private static final String SummaryVerifiableCredential =
       "{\n"
-          + "            \"credentialSubject\": [\n"
-          + "                {\n"
+          + "            \"credentialSubject\": {\n"
           + "                    \"contractTemplate\": \"https://public.catena-x.org/contracts/\",\n"
           + "                    \"holderIdentifier\": \"BPN12345678\",\n"
           + "                    \"id\": \"did:web:localhost%3A8080:BPN12345678\",\n"
@@ -45,8 +44,7 @@ class LinkedDataTransformerTest {
           + "                        \"BpnCredential\"\n"
           + "                    ],\n"
           + "                    \"type\": \"SummaryCredential\"\n"
-          + "                }\n"
-          + "            ],\n"
+          + "                },\n"
           + "            \"issuanceDate\": \"2023-07-03T13:11:58Z\",\n"
           + "            \"id\": \"did:web:localhost%3A8080:BPNOPERATOR#f7626dd8-4d29-400a-b697-93e6c98cce02\",\n"
           + "            \"proof\": {\n"

--- a/src/test/resources/verifiable-credential/bpn-credential.json
+++ b/src/test/resources/verifiable-credential/bpn-credential.json
@@ -1,12 +1,10 @@
 {
 	"issuanceDate": "2023-06-02T14:01:50Z",
-	"credentialSubject": [
-		{
+	"credentialSubject": {
 			"bpn": "BPNL000000000000",
 			"id": "did:test:localhost:BPNL000000000000",
 			"type": "BpnCredential"
-		}
-	],
+  },
 	"id": "did:test:localhost:BPNL000000000000#6e563351-0465-4324-944a-89a3c7329a7e",
 	"proof": {
 		"proofPurpose": "proofPurpose",


### PR DESCRIPTION
WHAT
added credentialSubject as object support in vc.
removed credentialSubject type as array in vc.

WHY
<img width="968" alt="MicrosoftTeams-image (4)" src="https://github.com/Cofinity-X/SSI-agent-lib/assets/26240401/e0154570-4663-4ad1-ad9e-cf9a95926bc1">
As per Catena-X standard schema, credentialSubject type must object. 